### PR TITLE
fix: add missing period to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
       to provide a compact, feature-rich interface for component development. While X-Tag offers feature hooks for all Web Component APIs
       (Custom Elements, Shadow DOM, Templates, and HTML Imports), it only relies on Custom Element support to operate.
       In the absence of native Custom Element support, X-Tag uses a <a target="_blank" href="https://github.com/webcomponents/webcomponentsjs">polyfill</a>
-      shared with Google's Polymer framework. You can view our package options in the <a href="/builds">Builds</a> section</p>.
+      shared with Google's Polymer framework. You can view our package options in the <a href="/builds">Builds</a> section.</p>
 
 
       <hr/>

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
       to provide a compact, feature-rich interface for component development. While X-Tag offers feature hooks for all Web Component APIs
       (Custom Elements, Shadow DOM, Templates, and HTML Imports), it only relies on Custom Element support to operate.
       In the absence of native Custom Element support, X-Tag uses a <a target="_blank" href="https://github.com/webcomponents/webcomponentsjs">polyfill</a>
-      shared with Google's Polymer framework. You can view our package options in the <a href="/builds">Builds</a> section</p>
+      shared with Google's Polymer framework. You can view our package options in the <a href="/builds">Builds</a> section</p>.
 
 
       <hr/>


### PR DESCRIPTION
Adds a missing period to the home page. I'm not sure this is the latest source for https://x-tag.github.io? See also https://github.com/x-tag/x-tag.github.io/pull/14.